### PR TITLE
[Fix] SSR 기준 OG Meta 생성으로 카카오톡 공유 이미지 미노출 문제 해결

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,6 +11,7 @@ import '@/styles/normalize.css';
 import { useAuthSync } from '@/hooks/auth/use-auth-sync';
 
 import Head from 'next/head';
+import { Meta, createPageMeta, type MetaProps } from '@/seo';
 import { ChatbotLauncher, Loading } from '@/components';
 
 /**
@@ -30,6 +31,8 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
   const [isLocaleReady, setIsLocaleReady] = useState(false);
   const defaultAppName = 'kommatrip';
   const defaultAppTitle = 'Korean Wellness & K-beauty Tours in Seoul';
+  const defaultAppDescription =
+    'kommatrip is your guide to Korean Wellness & K-beauty tours in Seoul';
   const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
 
   useEffect(() => {
@@ -80,6 +83,17 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
   const appTitle =
     (messages?.common as { app?: { title?: string } } | undefined)?.app?.title || defaultAppTitle;
   const pageTitle = `${appName} | ${appTitle}`;
+  const pageDescription =
+    (messages?.common as { app?: { description?: string } } | undefined)?.app?.description ||
+    defaultAppDescription;
+  const resolvedMeta: MetaProps =
+    (pageProps as { meta?: MetaProps }).meta ??
+    createPageMeta({
+      pageTitle,
+      description: pageDescription,
+      path: router.asPath || '/',
+      image: '/og/OG_image.jpg',
+    });
 
   useEffect(() => {
     if (!gtmId) return;
@@ -107,12 +121,12 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
   return (
     <>
       <Head>
-        <title>{pageTitle}</title>
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1.0"
         />
       </Head>
+      <Meta {...resolvedMeta} />
       <SessionProvider session={session}>
         <AuthSync />
         <NextIntlClientProvider locale={locale} messages={messages}>


### PR DESCRIPTION
## 📝 관련 문서 레퍼런스
   ```
- [Issue] : #71 
   - [Slack] : 
   - [Notion] : 
   ```

<br/>

## 💻 주요 변경 사항은 무엇인가요?
- `_app.tsx`에서 전역적으로 Meta 컴포넌트 렌더링
- `pageProps.meta` 우선 전략 도입 (페이지별 SEO override 가능)
- 기본 Meta 생성 로직을 `_app.tsx`로 이동하여
  locale redirect 환경에서도 SSR HTML에 OG 메타 포함되도록 수정

### 해결된 문제
- 카카오톡 링크 공유 시 OG 이미지 미노출 문제
- locale(`/ko`) 기준 SSR HTML에 og:image가 누락되던 이슈

### 검증
- 페이지 소스 보기 및 curl로 SSR HTML 확인
- 카카오톡 공유 및 카카오 디버거로 OG 이미지 노출 확인

```bash
curl -L https://www.kommatrip.com/ko | grep og:image
   ```
   
<br/>

## 📚 추가된 라이브러리
   ```
   - [추가] : NO
   ```

<br/>

## 📱 결과 화면 (선택)

  
<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)
   ```
   -
   ```
