### PR TITLE
[Hotfix/reservation] 현장결제 표시 오류 및 결제 위젯 렌더링 문제

### DIFF
--- a/messages/en/booking-detail.json
+++ b/messages/en/booking-detail.json
@@ -24,6 +24,7 @@
     "language": "Language",
     "paymentMethod": "Payment Method",
     "payOnline": "Pay Online({currency})",
+    "payOnSite": "Pay on site",
     "paymentAmount": "Payment Amount",
     "finalPaymentAmount": "Final Payment Amount"
   },

--- a/messages/ja/booking-detail.json
+++ b/messages/ja/booking-detail.json
@@ -24,6 +24,7 @@
     "language": "言語",
     "paymentMethod": "支払い方法",
     "payOnline": "オンライン決済({currency})",
+    "payOnSite": "現地で支払い",
     "paymentAmount": "決済金額",
     "finalPaymentAmount": "最終決済金額"
   },

--- a/messages/ko/booking-detail.json
+++ b/messages/ko/booking-detail.json
@@ -24,6 +24,7 @@
     "language": "언어",
     "paymentMethod": "결제 수단",
     "payOnline": "온라인 결제({currency})",
+    "payOnSite": "현장 결제",
     "paymentAmount": "결제 금액",
     "finalPaymentAmount": "최종 결제 금액"
   },

--- a/src/hooks/reservation/booking-detail/mapper.ts
+++ b/src/hooks/reservation/booking-detail/mapper.ts
@@ -11,6 +11,7 @@ interface BuildBookingDetailDataParams {
   previousDetail: BookingDetailData | null;
   formatters: BookingDetailFormatters;
   payOnlineLabel: (currency: string) => string;
+  payOnSiteLabel: string;
 }
 
 export function buildBookingDetailData({
@@ -18,7 +19,9 @@ export function buildBookingDetailData({
   previousDetail,
   formatters,
   payOnlineLabel,
+  payOnSiteLabel,
 }: BuildBookingDetailDataParams): BookingDetailData {
+  const hasOnlinePayment = Boolean(reservation.display_order_id?.trim());
   const programInfo = reservation.program_info;
   const paymentCurrency =
     typeof reservation.currency === 'string' && reservation.currency.trim()
@@ -58,8 +61,8 @@ export function buildBookingDetailData({
       image: previousDetail?.providerInfo?.image || heroImage,
     },
     paymentInfo: {
-      method: payOnlineLabel(paymentCurrency),
-      currency: reservation.currency ?? previousDetail?.paymentInfo?.currency ?? null,
+      method: hasOnlinePayment ? payOnlineLabel(paymentCurrency) : payOnSiteLabel,
+      currency: hasOnlinePayment ? (reservation.currency ?? 'KRW') : null,
       amount: formatters.formatAmount(programPrice, paymentCurrency),
       finalAmount: formatters.formatAmount(programPrice, paymentCurrency),
     },

--- a/src/hooks/reservation/use-booking-detail-view-model.ts
+++ b/src/hooks/reservation/use-booking-detail-view-model.ts
@@ -80,6 +80,7 @@ export function useBookingDetailViewModel(): BookingDetailViewModel {
         previousDetail,
         formatters,
         payOnlineLabel: (currency) => t('labels.payOnline', { currency }),
+        payOnSiteLabel: t('labels.payOnSite'),
       });
     },
     [formatters, t]

--- a/src/pages/reservations/index.tsx
+++ b/src/pages/reservations/index.tsx
@@ -195,6 +195,17 @@ export default function ReservationPage() {
   const hasRenderedWidgetRef = useRef(false);
   const [isPolicyAccepted, setIsPolicyAccepted] = useState(false);
 
+  const closePaymentWidgetModal = () => {
+    if (typeof document !== 'undefined') {
+      document.getElementById('reservation-payment-methods-modal')?.replaceChildren();
+      document.getElementById('reservation-payment-agreement-modal')?.replaceChildren();
+    }
+    paymentWidgetsRef.current = null;
+    hasRenderedWidgetRef.current = false;
+    setIsWidgetReady(false);
+    setIsPaymentWidgetOpen(false);
+  };
+
   const [currentMonth, setCurrentMonth] = useState(() => {
     const now = new Date();
     return new Date(now.getFullYear(), now.getMonth(), 1);
@@ -1139,17 +1150,13 @@ export default function ReservationPage() {
         )}
         {isPaymentWidgetOpen && pendingDraft && (
           <>
-            <Dim fullScreen onClick={() => setIsPaymentWidgetOpen(false)} />
+            <Dim fullScreen onClick={closePaymentWidgetModal} />
             <div css={paymentWidgetModal}>
               <div css={paymentWidgetHeader}>
                 <Text typo="title_M" color="text_primary">
                   {t('payment.tossWidgetTitle')}
                 </Text>
-                <button
-                  type="button"
-                  css={modalClose}
-                  onClick={() => setIsPaymentWidgetOpen(false)}
-                >
+                <button type="button" css={modalClose} onClick={closePaymentWidgetModal}>
                   ×
                 </button>
               </div>


### PR DESCRIPTION
## 📝 관련 문서 레퍼런스
   ```
   - [Issue] : 
   - [Slack] : 
   - [Notion] : 
   ```

<br/>

## 💻 주요 변경 사항은 무엇인가요?
   ```
- 현장결제 예약이 'Pay Online(KRW)' -> `Pay on site`로 노출되도록 변경
- booking detail 번역 리소스에 현장결제 라벨 추가
- 결제 위젯 모달 종료 시 토스 위젯 DOM, ref, 렌더링 상태를 함께 초기화하도록 수정
- 결제 위젯 재오픈 시 위젯이 정상적으로 다시 렌더링되도록 보정

   ```
   
<br/>

## 📚 추가된 라이브러리
   ```
   - [추가] : NO
   ```

<br/>

## 📱 결과 화면 (선택)

  
<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)
   ```
   -
   ```
