### PR TITLE
[Refactor/home] 홈 페이지 ISR 전환 및 추천 업체 프리패치 제거

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,8 @@
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { dehydrate, useQueryClient } from '@tanstack/react-query';
-import type { GetServerSideProps } from 'next';
+import { useQueryClient } from '@tanstack/react-query';
+import type { GetStaticProps } from 'next';
 import {
   Layout,
   HeroSection,
@@ -14,21 +14,15 @@ import {
 } from '@/components';
 import { Meta, buildHomeJsonLd, createPageMeta } from '@/seo';
 import { useMediaQuery, useAuthState } from '@/hooks';
-import {
-  fetchRecommendedCompanyQuery,
-  getRecommendedCompanyQueryKey,
-  useGetRecommendedCompanyQuery,
-  useGetRecentCompanyQuery,
-} from '@/queries/company';
+import { useGetRecommendedCompanyQuery, useGetRecentCompanyQuery } from '@/queries/company';
 import { useAuthStore } from '@/store/auth';
 import { QUERY_KEYS } from '@/queries/query-keys';
 
 import { theme } from '@/styles';
 import { css } from '@emotion/react';
 import { ROUTES } from '@/constants';
-import { withI18nGssp } from '@/i18n/page-props';
+import { withI18nGsp } from '@/i18n/page-props';
 import { useCurrentLocale } from '@/i18n/navigation';
-import { createQueryClient } from '@/providers';
 
 interface HomePageProps {
   heroImages: string[];
@@ -36,6 +30,7 @@ interface HomePageProps {
 
 const ALLOWED_EXTS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.avif']);
 const MAX_RECENT_SKELETON_COUNT = 6;
+const HOME_REVALIDATE_SECONDS = 300;
 
 const normalizeSkeletonCount = (count: number) => {
   if (count <= 0) return 0;
@@ -279,11 +274,10 @@ export const bottom = css`
   height: 18px;
 `;
 
-export const getServerSideProps: GetServerSideProps<HomePageProps> =
-  withI18nGssp<HomePageProps>(async () => {
+export const getStaticProps: GetStaticProps<HomePageProps> =
+  withI18nGsp<HomePageProps>(async () => {
     const path = await import('node:path');
     const { readdir } = await import('node:fs/promises');
-    const queryClient = createQueryClient();
 
     const dir = path.join(process.cwd(), 'public', 'images', 'hero');
     let heroImages: string[] = [];
@@ -300,15 +294,10 @@ export const getServerSideProps: GetServerSideProps<HomePageProps> =
       heroImages = [];
     }
 
-    await queryClient.prefetchQuery({
-      queryKey: getRecommendedCompanyQueryKey(),
-      queryFn: fetchRecommendedCompanyQuery,
-    });
-
     return {
       props: {
         heroImages,
-        dehydratedState: dehydrate(queryClient),
       },
+      revalidate: HOME_REVALIDATE_SECONDS,
     };
   }, ['common']);


### PR DESCRIPTION
## 📝 관련 문서 레퍼런스
   ```
   - [Issue] : #119 
   - [Slack] : 
   - [Notion] : 
   ```

<br/>

## 💻 주요 변경 사항은 무엇인가요?
   ```
- 홈(`/`) 렌더링 전략을 `getServerSideProps` 기반 SSR에서 `getStaticProps` 기반 ISR로 전환
- `revalidate`를 `300초`로 설정
- 추천 업체 서버 프리패치 제거
- 추천 업체는 기존 skeleton 흐름을 유지한 채 클라이언트에서 조회하도록 정리
- Lighthouse 기준 초기 렌더 지표 개선
- production 기준 Lighthouse에서 `Performance 100`, `LCP 0.8s` 확인
```
   
<br/>

## 📚 추가된 라이브러리
   ```
   - [추가] : NO
   ```

<br/>

## 📱 결과 화면 (선택)

  
<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)
   ```
- 최근 본 업체는 로그인 상태 기반 개인화 영역이므로 기존처럼 클라이언트 조회를 유지했습니다.
- 전역 JS 경량화 및 3rd-party 로드 최적화는 다음 브랜치에서 진행 예정입니다.   
-    ```
