### PR TITLE
[Feature/price] 더게이트 스파 30% 할인 배지 및 할인 가격 UI 적용

### DIFF
--- a/src/components/company-detail/company-program/index.tsx
+++ b/src/components/company-detail/company-program/index.tsx
@@ -6,15 +6,23 @@ import { ProgramCardSkeletonList, Empty } from '@/components';
 import { formatNumberWithCurrencyCode } from '@/i18n/format';
 import { useCurrentLocale } from '@/i18n/navigation';
 import { resolvePrice } from '@/utils/price';
+import { getTheGateSpaPriceDisplay } from '@/utils/the-gate-spa-discount';
 
 import { container, wrapper } from './index.styles';
 
 interface CompanyProgramProps {
   badges?: string[];
   companyId: number;
+  companyName?: string;
+  companyCode?: string;
 }
 
-export function CompanyProgram({ badges, companyId }: CompanyProgramProps) {
+export function CompanyProgram({
+  badges,
+  companyId,
+  companyName,
+  companyCode,
+}: CompanyProgramProps) {
   const locale = useCurrentLocale();
   const t = useTranslations('program');
   const { data, isLoading } = useGetProgramCompanyListQuery({
@@ -24,6 +32,10 @@ export function CompanyProgram({ badges, companyId }: CompanyProgramProps) {
   });
 
   const programs = data?.programs ?? [];
+  const discountCompany = {
+    name: companyName ?? data?.company_name,
+    company_code: companyCode ?? data?.company_code,
+  };
 
   return (
     <div css={container}>
@@ -39,17 +51,21 @@ export function CompanyProgram({ badges, companyId }: CompanyProgramProps) {
               currency: 'KRW',
               priceInfo: program.price_info,
             });
+            const priceDisplay = getTheGateSpaPriceDisplay({
+              company: discountCompany,
+              discountedPrice: resolvedPrice,
+              currency: 'KRW',
+              formatAmount: (price, currency) =>
+                formatNumberWithCurrencyCode(price, locale, currency),
+              fallbackText: '-',
+            });
 
             return (
               <ProgramCard
                 key={program.id}
                 title={program.name}
                 duration={t('duration', { minutes: program.duration_minutes })}
-                price={
-                  typeof resolvedPrice === 'number'
-                    ? formatNumberWithCurrencyCode(resolvedPrice, locale, 'KRW')
-                    : '-'
-                }
+                price={priceDisplay}
                 image={program.primary_image_url || program.image_urls?.[0] || '/default.png'}
                 badges={badges}
                 companyId={String(companyId)}

--- a/src/components/company-detail/program-card/index.styles.ts
+++ b/src/components/company-detail/program-card/index.styles.ts
@@ -21,6 +21,13 @@ export const itemWrapper = css`
   gap: 6px;
 `;
 
+export const programTitleRow = css`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+`;
+
 export const tags = css`
   display: flex;
   flex-wrap: wrap;
@@ -56,4 +63,36 @@ export const separator = css`
   margin: 0 4px;
 
   background-color: ${theme.colors.text_secondary};
+`;
+
+export const discountPriceGroup = css`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px;
+`;
+
+export const discountRateBadge = css`
+  display: inline-flex;
+  align-items: center;
+
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 4px;
+
+  background: ${theme.colors.red200};
+  color: ${theme.colors.white};
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
+`;
+
+export const originalPriceText = css`
+  color: ${theme.colors.text_disabled};
+  text-decoration: line-through;
+`;
+
+export const discountedPriceText = css`
+  color: ${theme.colors.red200};
+  font-weight: 500;
 `;

--- a/src/components/company-detail/program-card/index.tsx
+++ b/src/components/company-detail/program-card/index.tsx
@@ -12,18 +12,24 @@ import {
 } from '@/utils/image';
 
 import {
+  discountedPriceText,
+  discountPriceGroup,
+  discountRateBadge,
   infoWrapper,
   itemWrapper,
   itemImage,
+  originalPriceText,
   programDetails,
+  programTitleRow,
   detailRow,
   separator,
 } from './index.styles';
+import type { ProgramPriceDisplay } from '@/utils/the-gate-spa-discount';
 
 interface ProgramCardProps {
   title: string;
   duration: string;
-  price: string;
+  price: ProgramPriceDisplay;
   image: string;
   badges?: string[];
   companyId?: string;
@@ -55,6 +61,18 @@ export function ProgramCard({
   const imageSrc = hasImageError ? '/default.png' : normalizedImageSrc;
   const shouldUseNextImage = isOptimizableImage(imageSrc);
   const shouldBypassOptimization = shouldBypassNextImageOptimization(imageSrc);
+  const renderPrice = (priceDisplay: ProgramPriceDisplay) => {
+    if (priceDisplay.type === 'discount') {
+      return (
+        <span css={discountPriceGroup}>
+          <span css={originalPriceText}>{priceDisplay.originalPriceText}</span>
+          <span css={discountedPriceText}>{priceDisplay.discountedPriceText}</span>
+        </span>
+      );
+    }
+
+    return priceDisplay.priceText;
+  };
 
   return (
     <div css={infoWrapper} onClick={handleCardClick} style={{ cursor: 'pointer' }}>
@@ -80,9 +98,14 @@ export function ProgramCard({
         />
       )}
       <div css={itemWrapper}>
-        <Text typo="title_M" color="text_primary">
-          {title}
-        </Text>
+        <div css={programTitleRow}>
+          <Text typo="title_M" color="text_primary">
+            {title}
+          </Text>
+          {price.type === 'discount' && (
+            <span css={discountRateBadge}>{price.discountRateText}</span>
+          )}
+        </div>
         <div css={programDetails}>
           <div css={detailRow}>
             <Clock width={16} height={16} />
@@ -91,7 +114,7 @@ export function ProgramCard({
             </Text>
             <div css={separator} />
             <Text typo="button_S" color="text_secondary">
-              {price}
+              {renderPrice(price)}
             </Text>
           </div>
         </div>

--- a/src/components/company/company-card/index.styles.ts
+++ b/src/components/company/company-card/index.styles.ts
@@ -108,18 +108,46 @@ export const titleRow = css`
   gap: 8px;
 `;
 
-export const titleText = css`
+export const titleNameGroup = css`
+  display: inline-flex;
   flex: 1;
+  align-items: center;
+  gap: 6px;
   overflow: hidden;
 
   min-width: 0;
+`;
+
+export const titleText = css`
+  flex: 0 1 auto;
+  overflow: hidden;
+
+  min-width: 0;
+  max-width: 100%;
 
   white-space: nowrap;
   text-overflow: ellipsis;
 `;
 
+export const discountBadge = css`
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 4px;
+
+  background: ${theme.colors.red200};
+  color: ${theme.colors.white};
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+`;
+
 export const exclusiveBadge = css`
   display: inline-flex;
+  flex-shrink: 0;
   align-items: center;
 
   padding: 2px 8px;

--- a/src/components/company/company-card/index.tsx
+++ b/src/components/company/company-card/index.tsx
@@ -4,6 +4,7 @@ import { Location, ChevronLeftWhite } from '@/icons';
 import NextImage from 'next/image';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { normalizeSafeImageSrc, shouldBypassNextImageOptimization } from '@/utils/image';
+import { isTheGateSpaCompany } from '@/utils/the-gate-spa-discount';
 import { useTranslations } from 'next-intl';
 import {
   wrapper,
@@ -16,7 +17,9 @@ import {
   tagsFixedHeight,
   ratingBadge,
   titleRow,
+  titleNameGroup,
   titleText,
+  discountBadge,
   exclusiveBadge,
   wrapperCompact,
   profileWrapperCompact,
@@ -79,6 +82,7 @@ export function CompanyCard({
   }, [images, companyImage]);
   const currentImageUrl = imageList[currentImageIndex];
   const shouldBypassOptimization = shouldBypassNextImageOptimization(currentImageUrl);
+  const isDiscountCompany = isTheGateSpaCompany({ name: companyName });
 
   const handleImageError = () => {
     console.log('Image load failed, falling back to default image for:', companyName);
@@ -245,9 +249,12 @@ export function CompanyCard({
         ]}
       >
         <div css={titleRow}>
-          <Text typo="title_M" color="text_primary" css={titleText}>
-            {companyName}
-          </Text>
+          <div css={titleNameGroup}>
+            <Text typo="title_M" color="text_primary" css={titleText}>
+              {companyName}
+            </Text>
+            {isDiscountCompany && <span css={discountBadge}>30%</span>}
+          </div>
           {isExclusive && <span css={exclusiveBadge}>{t('company.exclusive')}</span>}
         </div>
 

--- a/src/components/company/company-detail/index.styles.ts
+++ b/src/components/company/company-detail/index.styles.ts
@@ -130,6 +130,29 @@ export const DetailsWrapper = css`
   }
 `;
 
+export const companyTitleRow = css`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const discountBadge = css`
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 4px;
+
+  background: ${theme.colors.red200};
+  color: ${theme.colors.white};
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+`;
+
 export const address = css`
   display: flex;
   align-items: flex-start;

--- a/src/components/company/company-detail/index.tsx
+++ b/src/components/company/company-detail/index.tsx
@@ -5,10 +5,13 @@ import { HeroImage } from '@/components/common';
 import { useState } from 'react';
 import { useToast } from '@/hooks';
 import { useTranslations } from 'next-intl';
+import { isTheGateSpaCompany } from '@/utils/the-gate-spa-discount';
 import {
   wrapper,
   profileWrapper,
   DetailsWrapper,
+  companyTitleRow,
+  discountBadge,
   address,
   addressText,
   copyButton,
@@ -24,6 +27,7 @@ import {
 interface Props {
   companyImage: string;
   companyName: string;
+  companyCode?: string;
   companyAddress: string;
   badges: string[];
   images?: string[]; // 이미지 캐러셀용 배열 추가
@@ -33,6 +37,7 @@ interface Props {
 export default function CompanyDetail({
   companyImage,
   companyName,
+  companyCode,
   companyAddress,
   badges,
   images = [],
@@ -40,6 +45,10 @@ export default function CompanyDetail({
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const { showToast } = useToast();
   const t = useTranslations('company-detail');
+  const isDiscountCompany = isTheGateSpaCompany({
+    name: companyName,
+    company_code: companyCode,
+  });
 
   // 이미지 배열이 있으면 사용, 없으면 기본 이미지 사용
   const imageList = images.length > 0 ? images : [companyImage];
@@ -126,9 +135,12 @@ export default function CompanyDetail({
         )}
       </div>
       <div css={DetailsWrapper}>
-        <Text typo="title_M" color="text_primary">
-          {companyName}
-        </Text>
+        <div css={companyTitleRow}>
+          <Text typo="title_M" color="text_primary">
+            {companyName}
+          </Text>
+          {isDiscountCompany && <span css={discountBadge}>30%</span>}
+        </div>
         <div css={address}>
           <Text typo="body_M" color="text_secondary" css={addressText}>
             {companyAddress}

--- a/src/components/reservation/company-info/index.styles.ts
+++ b/src/components/reservation/company-info/index.styles.ts
@@ -18,6 +18,29 @@ export const card = css`
   }
 `;
 
+export const titleRow = css`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const discountBadge = css`
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 4px;
+
+  background: ${theme.colors.red200};
+  color: ${theme.colors.white};
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+`;
+
 export const locationRow = css`
   display: flex;
   align-items: center;

--- a/src/components/reservation/company-info/index.tsx
+++ b/src/components/reservation/company-info/index.tsx
@@ -1,6 +1,15 @@
 import { ReactNode } from 'react';
 import { Text } from '@/components';
-import { card, locationIcon, locationRow, tagChip, tagList } from './index.styles';
+import { isTheGateSpaCompany } from '@/utils/the-gate-spa-discount';
+import {
+  card,
+  discountBadge,
+  locationIcon,
+  locationRow,
+  tagChip,
+  tagList,
+  titleRow,
+} from './index.styles';
 
 interface Props {
   name: string;
@@ -17,11 +26,16 @@ export function CompanyInfoCard({
   addressIconNode,
   variant = 'reservation',
 }: Props) {
+  const isDiscountCompany = isTheGateSpaCompany({ name });
+
   return (
     <div css={card}>
-      <Text typo="title_L" color="text_primary">
-        {name}
-      </Text>
+      <div css={titleRow}>
+        <Text typo="title_L" color="text_primary">
+          {name}
+        </Text>
+        {isDiscountCompany && <span css={discountBadge}>30%</span>}
+      </div>
       {address && (
         <div css={locationRow}>
           {addressIconNode && <span css={locationIcon}>{addressIconNode}</span>}

--- a/src/components/reservation/program-section/index.styles.ts
+++ b/src/components/reservation/program-section/index.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme } from '@/styles';
+import { theme, typography } from '@/styles';
 
 export const sectionCard = css`
   margin: 12px 16px 8px;
@@ -72,4 +72,43 @@ export const programInfo = css`
   flex-direction: column;
   justify-content: center;
   gap: 4px;
+`;
+
+export const programTitleRow = css`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+`;
+
+export const discountPriceGroup = css`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px;
+`;
+
+export const discountRateBadge = css`
+  display: inline-flex;
+  align-items: center;
+
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 4px;
+
+  background: ${theme.colors.red200};
+  color: ${theme.colors.white};
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
+`;
+
+export const originalPriceText = css`
+  color: ${theme.colors.text_disabled};
+  text-decoration: line-through;
+`;
+
+export const discountedPriceText = css`
+  color: ${theme.colors.red200};
+  ${typography.button_S};
 `;

--- a/src/components/reservation/program-section/index.tsx
+++ b/src/components/reservation/program-section/index.tsx
@@ -3,11 +3,17 @@ import { Text } from '@/components';
 import { Chevron } from '@/icons';
 import { css } from '@emotion/react';
 import { Skeleton } from '@/components/common/skeleton';
+import type { ProgramPriceDisplay } from '@/utils/the-gate-spa-discount';
 import {
   chevronIcon,
+  discountedPriceText,
+  discountPriceGroup,
+  discountRateBadge,
+  originalPriceText,
   programCard,
   programImage,
   programInfo,
+  programTitleRow,
   sectionCard,
   sectionContent,
   sectionHeader,
@@ -32,7 +38,7 @@ interface Props {
   selectedProgramId: number | null;
   onSelectProgram: (programId: number) => void;
   formatDuration: (minutes?: number) => string;
-  formatPrice: (priceInfo?: { krw: number; usd: number }) => string;
+  formatPrice: (priceInfo?: { krw: number; usd: number }) => ProgramPriceDisplay;
 }
 
 export function ProgramSection({
@@ -46,6 +52,18 @@ export function ProgramSection({
   formatPrice,
 }: Props) {
   const t = useTranslations('reservation');
+  const renderPrice = (priceDisplay: ProgramPriceDisplay) => {
+    if (priceDisplay.type === 'discount') {
+      return (
+        <span css={discountPriceGroup}>
+          <span css={originalPriceText}>{priceDisplay.originalPriceText}</span>
+          <span css={discountedPriceText}>{priceDisplay.discountedPriceText}</span>
+        </span>
+      );
+    }
+
+    return priceDisplay.priceText;
+  };
 
   return (
     <div css={sectionCard}>
@@ -77,27 +95,36 @@ export function ProgramSection({
           )}
 
           {!isLoading &&
-            programs.map((program) => (
-              <div
-                key={program.id}
-                css={programCard(selectedProgramId === program.id)}
-                onClick={() => onSelectProgram(program.id)}
-              >
-                <img
-                  src={program.primary_image_url || '/default.png'}
-                  alt={program.name}
-                  css={programImage}
-                />
-                <div css={programInfo}>
-                  <Text typo="title_S" color="text_primary">
-                    {program.name}
-                  </Text>
-                  <Text typo="body_S" color="text_tertiary">
-                    ⏱ {formatDuration(program.duration_minutes)} | {formatPrice(program.price_info)}
-                  </Text>
+            programs.map((program) => {
+              const priceDisplay = formatPrice(program.price_info);
+
+              return (
+                <div
+                  key={program.id}
+                  css={programCard(selectedProgramId === program.id)}
+                  onClick={() => onSelectProgram(program.id)}
+                >
+                  <img
+                    src={program.primary_image_url || '/default.png'}
+                    alt={program.name}
+                    css={programImage}
+                  />
+                  <div css={programInfo}>
+                    <div css={programTitleRow}>
+                      <Text typo="title_S" color="text_primary">
+                        {program.name}
+                      </Text>
+                      {priceDisplay.type === 'discount' && (
+                        <span css={discountRateBadge}>{priceDisplay.discountRateText}</span>
+                      )}
+                    </div>
+                    <Text typo="body_S" color="text_tertiary">
+                      ⏱ {formatDuration(program.duration_minutes)} | {renderPrice(priceDisplay)}
+                    </Text>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
         </div>
       )}
     </div>

--- a/src/pages/company/[companyId]/index.tsx
+++ b/src/pages/company/[companyId]/index.tsx
@@ -348,6 +348,7 @@ export default function ClinicDetailPage({
                 badges={company.tags || []}
                 companyImage={company.primary_image_url || '/default.png'}
                 companyName={company.name}
+                companyCode={company.company_code}
                 companyAddress={company.address}
                 images={company.image_urls || []}
               />
@@ -373,7 +374,12 @@ export default function ClinicDetailPage({
                   </div>
 
                   <div ref={programRef} data-section="program" css={section}>
-                    <CompanyProgram badges={company.tags || []} companyId={companyIdNumber} />
+                    <CompanyProgram
+                      badges={company.tags || []}
+                      companyId={companyIdNumber}
+                      companyName={company.name}
+                      companyCode={company.company_code}
+                    />
                   </div>
 
                   <div ref={reviewRef} data-section="review" css={section}>

--- a/src/pages/company/[companyId]/program/[programId].tsx
+++ b/src/pages/company/[companyId]/program/[programId].tsx
@@ -33,6 +33,7 @@ import {
   shouldBypassNextImageOptimization,
 } from '@/utils/image';
 import { resolvePrice } from '@/utils/price';
+import { getTheGateSpaPriceDisplay } from '@/utils/the-gate-spa-discount';
 import { createQueryClient } from '@/providers';
 
 interface ProgramDetailPageProps extends Record<string, unknown> {
@@ -195,10 +196,13 @@ export default function ProgramDetailPage({
     currency: 'KRW',
     priceInfo: program.price_info,
   });
-  const formattedPrice =
-    typeof krwPrice === 'number'
-      ? formatNumberWithCurrencyCode(krwPrice, currentLocale, 'KRW')
-      : '-';
+  const priceDisplay = getTheGateSpaPriceDisplay({
+    company: schemaCompany ?? { company_code: program.company_code },
+    discountedPrice: krwPrice,
+    currency: 'KRW',
+    formatAmount: (price, currency) => formatNumberWithCurrencyCode(price, currentLocale, currency),
+    fallbackText: '-',
+  });
   const bookingInfo = program.booking_information?.replace(/\\n/g, '\n') ?? '';
   const refundInfo = program.refund_regulation?.replace(/\\n/g, '\n') ?? '';
   const processItems = program.process ?? [];
@@ -248,9 +252,14 @@ export default function ProgramDetailPage({
                   )}
                 </div>
 
-                <Text typo="title_L" color="text_primary" css={programTitle}>
-                  {program.name}
-                </Text>
+                <div css={programTitle}>
+                  <Text typo="title_L" color="text_primary">
+                    {program.name}
+                  </Text>
+                  {priceDisplay.type === 'discount' && (
+                    <span css={discountRateBadge}>{priceDisplay.discountRateText}</span>
+                  )}
+                </div>
               </div>
               <div css={programSection}>
                 <div css={titleWrapper}>
@@ -268,7 +277,14 @@ export default function ProgramDetailPage({
                   <div css={infoRow}>
                     <Wallet width={16} height={16} />
                     <Text typo="button_S" color="text_secondary">
-                      {formattedPrice}
+                      {priceDisplay.type === 'discount' ? (
+                        <span css={discountPriceGroup}>
+                          <span css={originalPriceText}>{priceDisplay.originalPriceText}</span>
+                          <span css={discountedPriceText}>{priceDisplay.discountedPriceText}</span>
+                        </span>
+                      ) : (
+                        priceDisplay.priceText
+                      )}
                     </Text>
                   </div>
                 </div>
@@ -520,6 +536,11 @@ const programSection = css`
 `;
 
 const programTitle = css`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+
   padding: 16px 20px;
 
   @media (min-width: ${theme.breakpoints.desktop}) {
@@ -562,6 +583,38 @@ const infoRow = css`
   &:last-child {
     margin-bottom: 0;
   }
+`;
+
+const discountPriceGroup = css`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px;
+`;
+
+const discountRateBadge = css`
+  display: inline-flex;
+  align-items: center;
+
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 4px;
+
+  background: ${theme.colors.red200};
+  color: ${theme.colors.white};
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
+`;
+
+const originalPriceText = css`
+  color: ${theme.colors.text_disabled};
+  text-decoration: line-through;
+`;
+
+const discountedPriceText = css`
+  color: ${theme.colors.red200};
+  font-weight: 500;
 `;
 
 const processSection = css`

--- a/src/pages/reservations/index.tsx
+++ b/src/pages/reservations/index.tsx
@@ -48,6 +48,7 @@ import {
   getCompanyAvailableReservationTimes,
   isCompanyClosedOnDate,
 } from '@/utils/company-schedule';
+import { getTheGateSpaPriceDisplay, type ProgramPriceDisplay } from '@/utils/the-gate-spa-discount';
 
 interface ReservationDraft {
   company_id: number;
@@ -616,6 +617,10 @@ export default function ReservationPage() {
     return `${minutes} ${t('form.programs.minutes')}`;
   };
 
+  const formatAmountByCurrency = (price: number, currency: CurrencyCode) => {
+    return `${new Intl.NumberFormat(locale).format(price)} ${currency}`;
+  };
+
   const formatPriceByCurrency = (
     priceInfo: { krw: number; usd: number } | undefined,
     currency: CurrencyCode
@@ -625,11 +630,29 @@ export default function ReservationPage() {
       priceInfo,
     });
     if (typeof price !== 'number') return '';
-    return `${new Intl.NumberFormat(locale).format(price)} ${currency}`;
+    return formatAmountByCurrency(price, currency);
+  };
+
+  const getPriceDisplay = (
+    priceInfo: { krw: number; usd: number } | undefined,
+    currency: CurrencyCode
+  ): ProgramPriceDisplay => {
+    const discountedPrice = resolvePrice({
+      currency,
+      priceInfo,
+    });
+
+    return getTheGateSpaPriceDisplay({
+      company,
+      discountedPrice,
+      currency,
+      formatAmount: formatAmountByCurrency,
+      fallbackText: formatPriceByCurrency(priceInfo, currency),
+    });
   };
 
   const formatPrice = (priceInfo?: { krw: number; usd: number }) => {
-    return formatPriceByCurrency(priceInfo, 'KRW');
+    return getPriceDisplay(priceInfo, 'KRW');
   };
 
   const toTimeString = (timeString: string) => {
@@ -895,9 +918,12 @@ export default function ReservationPage() {
   const summaryDateKey = summaryDate ? formatDateForRequest(summaryDate) : '';
   const summaryTimes = summaryDateKey ? (selectedTimes[summaryDateKey] ?? []) : [];
   const summaryTimeText = summaryTimes.length > 0 ? summaryTimes.join(' / ') : '-';
-  const summaryPriceText = selectedProgram
-    ? formatPriceByCurrency(selectedProgram.price_info, selectedPaymentCurrency) || '-'
-    : '-';
+  const summaryPriceDisplay = selectedProgram
+    ? getPriceDisplay(selectedProgram.price_info, selectedPaymentCurrency)
+    : ({
+        type: 'regular',
+        priceText: '-',
+      } satisfies ProgramPriceDisplay);
 
   const handleOpenRefundPolicy = () => {
     if (typeof window === 'undefined') return;
@@ -1125,11 +1151,21 @@ export default function ReservationPage() {
                       {t('payment.program')}
                     </Text>
                     <Text typo="title_S" color="text_primary" css={summaryValueRight}>
-                      {selectedProgram
-                        ? `${selectedProgram.name} (${selectedProgram.duration_minutes}${t(
-                            'payment.minutes'
-                          )})`
-                        : '-'}
+                      {selectedProgram ? (
+                        <span css={summaryProgramNameGroup}>
+                          <span>
+                            {selectedProgram.name} ({selectedProgram.duration_minutes}
+                            {t('payment.minutes')})
+                          </span>
+                          {summaryPriceDisplay.type === 'discount' && (
+                            <span css={summaryDiscountRateBadge}>
+                              {summaryPriceDisplay.discountRateText}
+                            </span>
+                          )}
+                        </span>
+                      ) : (
+                        '-'
+                      )}
                     </Text>
                   </div>
                 </div>
@@ -1143,7 +1179,13 @@ export default function ReservationPage() {
                       {t('payment.paymentAmountLabel')}
                     </Text>
                     <Text typo="body_M" color="text_primary">
-                      {summaryPriceText}
+                      {summaryPriceDisplay.type === 'discount' ? (
+                        <span css={summaryOriginalPriceText}>
+                          {summaryPriceDisplay.originalPriceText}
+                        </span>
+                      ) : (
+                        summaryPriceDisplay.priceText
+                      )}
                     </Text>
                   </div>
                   <div css={summaryDivider} />
@@ -1151,8 +1193,13 @@ export default function ReservationPage() {
                     <Text typo="title_S" color="text_primary">
                       {t('payment.finalPaymentAmount')}
                     </Text>
-                    <Text typo="title_S" color="primary50">
-                      {summaryPriceText}
+                    <Text
+                      typo="title_S"
+                      color={summaryPriceDisplay.type === 'discount' ? 'red200' : 'primary50'}
+                    >
+                      {summaryPriceDisplay.type === 'discount'
+                        ? summaryPriceDisplay.discountedPriceText
+                        : summaryPriceDisplay.priceText}
                     </Text>
                   </div>
                 </div>
@@ -1519,6 +1566,34 @@ const summaryRow = css`
 
 const summaryValueRight = css`
   text-align: right;
+`;
+
+const summaryProgramNameGroup = css`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+`;
+
+const summaryOriginalPriceText = css`
+  color: ${theme.colors.text_disabled};
+  text-decoration: line-through;
+`;
+
+const summaryDiscountRateBadge = css`
+  display: inline-flex;
+  align-items: center;
+
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 4px;
+
+  background: ${theme.colors.red200};
+  color: ${theme.colors.white};
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
 `;
 
 const summaryDivider = css`

--- a/src/pages/reservations/payment/index.tsx
+++ b/src/pages/reservations/payment/index.tsx
@@ -36,6 +36,7 @@ import type { LanguagePreference } from '@/models/reservation';
 import type { CurrencyCode } from '@/utils/price';
 import { getI18nServerSideProps } from '@/i18n/page-props';
 import { RESERVATION_REFUND_POLICY_URL } from '@/utils/reservation-policy';
+import { getTheGateSpaPriceDisplay, type ProgramPriceDisplay } from '@/utils/the-gate-spa-discount';
 
 interface ReservationDraft {
   company_id: number;
@@ -112,8 +113,24 @@ export default function ReservationPaymentPage() {
   };
 
   const formatPrice = (price: number) => new Intl.NumberFormat(locale).format(price);
+  const formatAmountByCurrency = (price: number, currency: CurrencyCode) => {
+    return `${formatPrice(price)} ${currency}`;
+  };
   const normalizeCurrency = (currency?: string): CurrencyCode => {
     return currency === 'USD' ? 'USD' : 'KRW';
+  };
+  const getAmountDisplay = (
+    amount: number | null,
+    currency: CurrencyCode,
+    companyName?: string
+  ): ProgramPriceDisplay => {
+    return getTheGateSpaPriceDisplay({
+      company: { name: companyName },
+      discountedPrice: typeof amount === 'number' ? amount : undefined,
+      currency,
+      formatAmount: formatAmountByCurrency,
+      fallbackText: '-',
+    });
   };
 
   useEffect(() => {
@@ -139,6 +156,7 @@ export default function ReservationPaymentPage() {
   const displayCurrency: CurrencyCode = isPayNowPayment
     ? normalizeCurrency(paymentOrder?.currency ?? selectedPaymentCurrency)
     : 'KRW';
+  const amountDisplay = getAmountDisplay(displayAmount, displayCurrency, draft?.company_name);
 
   const handleOpenRefundPolicy = () => {
     if (typeof window === 'undefined') return;
@@ -446,8 +464,15 @@ export default function ReservationPaymentPage() {
                     {t('payment.program')}
                   </Text>
                   <Text typo="title_S" color="text_primary" css={programText}>
-                    {draft.program_name} ({draft.program_duration_minutes}
-                    {t('payment.minutes')})
+                    <span css={programNameGroup}>
+                      <span>
+                        {draft.program_name} ({draft.program_duration_minutes}
+                        {t('payment.minutes')})
+                      </span>
+                      {amountDisplay.type === 'discount' && (
+                        <span css={amountDiscountRateBadge}>{amountDisplay.discountRateText}</span>
+                      )}
+                    </span>
                   </Text>
                 </div>
               </div>
@@ -526,9 +551,11 @@ export default function ReservationPaymentPage() {
                       {t('payment.paymentAmountLabel')}
                     </Text>
                     <Text typo="body_M" color="text_primary">
-                      {typeof displayAmount === 'number'
-                        ? `${formatPrice(displayAmount)} ${displayCurrency}`
-                        : '-'}
+                      {amountDisplay.type === 'discount' ? (
+                        <span css={amountOriginalPriceText}>{amountDisplay.originalPriceText}</span>
+                      ) : (
+                        amountDisplay.priceText
+                      )}
                     </Text>
                   </div>
                   <div css={divider} />
@@ -536,10 +563,13 @@ export default function ReservationPaymentPage() {
                     <Text typo="title_S" color="text_primary">
                       {t('payment.finalPaymentAmount')}
                     </Text>
-                    <Text typo="title_S" color="primary50">
-                      {typeof displayAmount === 'number'
-                        ? `${formatPrice(displayAmount)} ${displayCurrency}`
-                        : '-'}
+                    <Text
+                      typo="title_S"
+                      color={amountDisplay.type === 'discount' ? 'red200' : 'primary50'}
+                    >
+                      {amountDisplay.type === 'discount'
+                        ? amountDisplay.discountedPriceText
+                        : amountDisplay.priceText}
                     </Text>
                   </div>
                 </div>
@@ -684,6 +714,14 @@ const programText = css`
   text-align: right;
 `;
 
+const programNameGroup = css`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+`;
+
 const paymentMethodOptions = css`
   display: flex;
   flex-wrap: wrap;
@@ -744,6 +782,26 @@ const amountRow = css`
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+`;
+
+const amountOriginalPriceText = css`
+  color: ${theme.colors.text_disabled};
+  text-decoration: line-through;
+`;
+
+const amountDiscountRateBadge = css`
+  display: inline-flex;
+  align-items: center;
+
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 4px;
+
+  background: ${theme.colors.red200};
+  color: ${theme.colors.white};
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
 `;
 
 const divider = css`

--- a/src/utils/the-gate-spa-discount.ts
+++ b/src/utils/the-gate-spa-discount.ts
@@ -1,0 +1,102 @@
+import type { CurrencyCode } from './price';
+
+const THE_GATE_SPA_IDENTIFIERS = ['더게이트스파', 'thegatespa'];
+const THE_GATE_SPA_DISCOUNT_RATE_TEXT = '30%';
+const THE_GATE_SPA_DISCOUNT_MULTIPLIER = 0.7;
+
+const normalizeIdentifier = (value?: string | null) =>
+  (value ?? '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣]/g, '');
+
+export const isTheGateSpaCompany = (
+  company?: {
+    name?: string | null;
+    company_code?: string | null;
+  } | null
+) => {
+  if (!company) return false;
+
+  return [company.name, company.company_code].some((value) => {
+    const normalizedValue = normalizeIdentifier(value);
+    return THE_GATE_SPA_IDENTIFIERS.some((identifier) => normalizedValue.includes(identifier));
+  });
+};
+
+export const resolveTheGateSpaOriginalPrice = ({
+  discountedPrice,
+  currency,
+}: {
+  discountedPrice: number;
+  currency: CurrencyCode;
+}) => {
+  if (!Number.isFinite(discountedPrice)) return undefined;
+
+  const originalPrice = discountedPrice / THE_GATE_SPA_DISCOUNT_MULTIPLIER;
+  if (currency === 'KRW') return Math.round(originalPrice);
+  return Number(originalPrice.toFixed(2));
+};
+
+export type ProgramPriceDisplay =
+  | {
+      type: 'regular';
+      priceText: string;
+    }
+  | {
+      type: 'discount';
+      discountRateText: string;
+      originalPriceText: string;
+      discountedPriceText: string;
+    };
+
+export const getTheGateSpaPriceDisplay = ({
+  company,
+  discountedPrice,
+  currency,
+  formatAmount,
+  fallbackText = '',
+}: {
+  company?: {
+    name?: string | null;
+    company_code?: string | null;
+  } | null;
+  discountedPrice?: number;
+  currency: CurrencyCode;
+  formatAmount: (price: number, currency: CurrencyCode) => string;
+  fallbackText?: string;
+}): ProgramPriceDisplay => {
+  if (typeof discountedPrice !== 'number') {
+    return {
+      type: 'regular',
+      priceText: fallbackText,
+    };
+  }
+
+  const priceText = formatAmount(discountedPrice, currency);
+  if (!isTheGateSpaCompany(company)) {
+    return {
+      type: 'regular',
+      priceText,
+    };
+  }
+
+  const originalPrice = resolveTheGateSpaOriginalPrice({
+    discountedPrice,
+    currency,
+  });
+
+  if (typeof originalPrice !== 'number') {
+    return {
+      type: 'regular',
+      priceText,
+    };
+  }
+
+  return {
+    type: 'discount',
+    discountRateText: THE_GATE_SPA_DISCOUNT_RATE_TEXT,
+    originalPriceText: formatAmount(originalPrice, currency),
+    discountedPriceText: priceText,
+  };
+};


### PR DESCRIPTION
## 📝 관련 문서 레퍼런스
   ```
   - [Issue] : #155 
   - [Slack] : 
   - [Notion] : 
   ```

<br/>

## 💻 주요 변경 사항은 무엇인가요?
   ```
  ### 할인 정책 유틸 추가

- 더게이트 스파 식별 유틸 추가
- `더게이트스파`, `thegatespa` 이름/코드 정규화 기준으로 판별
- 할인 가격 기준 정가 역산 로직 추가
- 공통 가격 표시 모델 추가
  - 일반 가격
  - 할인 가격
  - 정가
  - 할인가
  - `30%` 할인율 라벨

### 업체명 할인 배지 적용

- 업체 상세 상단 업체명 옆에 `30%` 배지 추가
- 메인 추천 업체 카드에 `30%` 배지 추가
- 최근 본 업체 카드에 `30%` 배지 추가
- 업체 리스트/검색 결과 등 `CompanyCard`를 사용하는 모든 더게이트 스파 카드에 `30%` 배지 추가
- 예약/결제 화면의 업체 정보 카드에도 `30%` 배지 추가

### 프로그램 할인 가격 UI 적용

- 예약 페이지 프로그램 목록에 할인 가격 UI 적용
- 업체 상세 프로그램 리스트에 할인 가격 UI 적용
- 프로그램 상세 페이지에 할인 가격 UI 적용
- 프로그램명 옆에 `30%` 배지 표시
- 가격 영역은 `정가 취소선 + 할인가 빨간색`으로 정리

### 예약/결제 요약 UI 적용

- 예약 페이지 결제 요약에 정가/할인가 표시
- 결제 페이지 요약에 정가/할인가 표시
- 프로그램명 옆에 `30%` 배지 표시
- 실제 예약/결제 금액은 기존 백엔드 가격 흐름 유지
   ```
   
<br/>

## 📚 추가된 라이브러리
   ```
   - [추가] : YES | NO
   ```

<br/>

## 📱 결과 화면 (선택)

  
<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)
   ```
   -
   ```
