### PR TITLE
[Fix/home-hero] 배포 환경 홈 히어로 롤링 정지 문제 수정

### DIFF
--- a/src/components/hero-section/index.tsx
+++ b/src/components/hero-section/index.tsx
@@ -80,7 +80,7 @@ export function HeroSection({
             fetchPriority={currentIndex === 0 ? 'high' : undefined}
             quality={75}
             css={[image, !isCurrentImageReady && settledImage && hiddenImage]}
-            onLoadingComplete={handleCurrentImageLoad}
+            onLoad={handleCurrentImageLoad}
           />
         </div>
         <div css={overlay} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,6 +28,10 @@ interface HomePageProps {
 }
 
 const ALLOWED_EXTS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.avif']);
+const DEFAULT_HERO_IMAGES = Array.from({ length: 7 }, (_, index) => {
+  const imageNumber = index + 1;
+  return `/images/hero/hero${imageNumber}.webp`;
+});
 const MAX_RECENT_SKELETON_COUNT = 6;
 const PRIORITY_RECOMMENDED_COMPANY_ID = 17; // TODO: 이벤트 기간 동안 우선순위로 노출, 기간 후 제거 예정
 
@@ -310,6 +314,12 @@ export const getServerSideProps: GetServerSideProps<HomePageProps> =
         .map((name) => `/images/hero/${name}`);
     } catch {
       heroImages = [];
+    }
+
+    // Standalone/server runtime에 따라 process.cwd() 기준 public 탐색이 실패할 수 있으므로
+    // 런타임 디렉터리와 무관한 기본 목록으로 보정한다.
+    if (heroImages.length === 0) {
+      heroImages = DEFAULT_HERO_IMAGES;
     }
 
     return {


### PR DESCRIPTION
## 📝 관련 문서 레퍼런스
   ```
   - [Issue] : #183 
   - [Slack] : 
   - [Notion] : 
   ```

<br/>

## 💻 주요 변경 사항은 무엇인가요?
   ```
1. 원인
- getServerSideProps의 런타임 파일 시스템 기반 hero 이미지 목록 조회 구조
- next/image의 onLoadingComplete 의존에 따른 첫 이미지 ready 상태 미보장

2. 변경 사항
- hero 이미지 목록 조회 실패 시 기본 hero 이미지 목록 fallback 적용
- 히어로 이미지 로드 감지 이벤트 onLoadingComplete → onLoad 변경
- 첫 이미지 ready 이후 autoplay 시작 조건 보강
   ```
   
<br/>

## 📚 추가된 라이브러리
   ```
   - [추가] : NO
   ```

<br/>

## 📱 결과 화면 (선택)

  
<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)
   ```
   -
   ```
