### PR TITLE
[Feature/admin-env] 어드민에 운영 서버와 테스트 서버를 선택해서 전환

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -46,6 +46,7 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_MAPS_API_KEY: process.env.NEXT_PUBLIC_MAPS_API_KEY,
     NEXT_PUBLIC_MAP_ID: process.env.NEXT_PUBLIC_MAP_ID,
+    NEXT_PUBLIC_ADMIN_TEST_BACKEND_ENABLED: process.env.BACKEND_TEST_API_URL ? 'true' : 'false',
     GEMINI_API_KEY: process.env.GEMINI_API_KEY,
     AWS_REGION: process.env.AWS_REGION,
     AWS_BUCKET: process.env.AWS_BUCKET,

--- a/src/components/admin/admin-backend-target-selector.tsx
+++ b/src/components/admin/admin-backend-target-selector.tsx
@@ -1,0 +1,80 @@
+import { css } from '@emotion/react';
+import { ADMIN_BACKEND_TARGET_LABELS, type AdminBackendTarget } from '@/constants/admin-backend';
+import { adminConsolePalette } from './admin-console.styles';
+
+interface AdminBackendTargetSelectorProps {
+  value: AdminBackendTarget;
+  onChange: (target: AdminBackendTarget) => void;
+  isTestEnabled: boolean;
+  disabled?: boolean;
+  compact?: boolean;
+}
+
+const BACKEND_TARGETS: AdminBackendTarget[] = ['prod', 'test'];
+
+export function AdminBackendTargetSelector({
+  value,
+  onChange,
+  isTestEnabled,
+  disabled = false,
+  compact = false,
+}: AdminBackendTargetSelectorProps) {
+  return (
+    <div css={selectorShell(compact)}>
+      <div css={buttonRow}>
+        {BACKEND_TARGETS.map((target) => {
+          const isActive = target === value;
+          const isTargetDisabled = disabled || (target === 'test' && !isTestEnabled);
+
+          return (
+            <button
+              key={target}
+              type="button"
+              css={targetButton(isActive)}
+              disabled={isTargetDisabled}
+              onClick={() => onChange(target)}
+            >
+              {ADMIN_BACKEND_TARGET_LABELS[target]}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const selectorShell = (compact: boolean) => css`
+  width: 100%;
+  min-width: ${compact ? '240px' : '100%'};
+`;
+
+const buttonRow = css`
+  display: flex;
+  width: 100%;
+  gap: 8px;
+  flex-wrap: nowrap;
+`;
+
+const targetButton = (isActive: boolean) => css`
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 42px;
+  padding: 0 14px;
+  border-radius: 14px;
+  border: 1px solid ${isActive ? adminConsolePalette.accent : adminConsolePalette.borderSoft};
+  background: ${isActive ? 'rgba(132, 155, 130, 0.18)' : 'rgba(255, 255, 255, 0.03)'};
+  color: ${isActive ? adminConsolePalette.textStrong : adminConsolePalette.textSubtle};
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease,
+    color 0.2s ease;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`;

--- a/src/components/admin/admin-topbar.tsx
+++ b/src/components/admin/admin-topbar.tsx
@@ -1,7 +1,17 @@
 import { css } from '@emotion/react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
+import { AdminBackendTargetSelector } from '@/components/admin/admin-backend-target-selector';
 import { Text } from '@/components/text';
+import { ADMIN_BACKEND_TARGET_LABELS, type AdminBackendTarget } from '@/constants/admin-backend';
+import { ROUTES } from '@/constants';
+import { useToast } from '@/hooks';
+import { useAdminAuth } from '@/hooks/admin/use-admin-auth';
+import {
+  getStoredAdminBackendTarget,
+  isAdminTestBackendEnabled,
+  persistAdminBackendTarget,
+} from '@/utils/admin-backend-target';
 import { adminConsolePalette } from './admin-console.styles';
 
 const resolvePageTitleSegments = (pathname: string) => {
@@ -38,7 +48,34 @@ const resolvePageTitleSegments = (pathname: string) => {
 
 export function AdminTopbar() {
   const router = useRouter();
+  const { showToast } = useToast();
+  const { logout } = useAdminAuth();
+  const [backendTarget, setBackendTarget] = useState<AdminBackendTarget>(() =>
+    getStoredAdminBackendTarget()
+  );
+  const [isSwitchingBackend, setIsSwitchingBackend] = useState(false);
   const titleSegments = useMemo(() => resolvePageTitleSegments(router.pathname), [router.pathname]);
+
+  const handleBackendTargetChange = async (nextTarget: AdminBackendTarget) => {
+    if (nextTarget === backendTarget || isSwitchingBackend) return;
+
+    setIsSwitchingBackend(true);
+    persistAdminBackendTarget(nextTarget);
+    setBackendTarget(nextTarget);
+
+    try {
+      await logout();
+      showToast({
+        title: `${ADMIN_BACKEND_TARGET_LABELS[nextTarget]}로 전환되어 다시 로그인해주세요.`,
+        icon: 'check',
+      });
+      await router.replace(
+        `${ROUTES.ADMIN_LOGIN}?next=${encodeURIComponent(router.asPath || ROUTES.ADMIN_DASHBOARD)}`
+      );
+    } finally {
+      setIsSwitchingBackend(false);
+    }
+  };
 
   return (
     <header css={topbar}>
@@ -57,6 +94,16 @@ export function AdminTopbar() {
           ))}
         </div>
       </div>
+
+      <div css={backendTargetBlock}>
+        <AdminBackendTargetSelector
+          value={backendTarget}
+          onChange={(target) => void handleBackendTargetChange(target)}
+          isTestEnabled={isAdminTestBackendEnabled}
+          disabled={isSwitchingBackend}
+          compact
+        />
+      </div>
     </header>
   );
 }
@@ -64,7 +111,7 @@ export function AdminTopbar() {
 const topbar = css`
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
   gap: 16px;
   padding: 20px 24px;
   border-bottom: 1px solid ${adminConsolePalette.borderSoft};
@@ -81,6 +128,17 @@ const topbar = css`
 const titleBlock = css`
   display: flex;
   min-width: 0;
+`;
+
+const backendTargetBlock = css`
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  max-width: 320px;
+
+  @media (max-width: 960px) {
+    max-width: none;
+  }
 `;
 
 const breadcrumbRow = css`

--- a/src/constants/admin-backend.ts
+++ b/src/constants/admin-backend.ts
@@ -1,0 +1,13 @@
+export type AdminBackendTarget = 'prod' | 'test';
+
+export const ADMIN_BACKEND_TARGET_COOKIE = 'adminBackendTarget';
+
+export const DEFAULT_ADMIN_BACKEND_TARGET: AdminBackendTarget = 'prod';
+
+export const ADMIN_BACKEND_TARGET_LABELS: Record<AdminBackendTarget, string> = {
+  prod: '운영 서버',
+  test: '테스트 서버',
+};
+
+export const isAdminBackendTarget = (value: unknown): value is AdminBackendTarget =>
+  value === 'prod' || value === 'test';

--- a/src/pages/admin/login.tsx
+++ b/src/pages/admin/login.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import { useRouter } from 'next/router';
+import { AdminBackendTargetSelector } from '@/components/admin/admin-backend-target-selector';
 import {
   adminAccentButton,
   adminConsolePalette,
@@ -10,10 +11,16 @@ import {
 } from '@/components/admin/admin-console.styles';
 import { Input } from '@/components/input';
 import { Text } from '@/components/text';
+import { ADMIN_BACKEND_TARGET_LABELS, type AdminBackendTarget } from '@/constants/admin-backend';
 import { ROUTES } from '@/constants';
 import { useToast } from '@/hooks';
 import { postAdminLogin, postAdminRegister } from '@/apis';
 import { getAdminI18nStaticProps } from '@/i18n/page-props';
+import {
+  getStoredAdminBackendTarget,
+  isAdminTestBackendEnabled,
+  persistAdminBackendTarget,
+} from '@/utils/admin-backend-target';
 import { applyAdminAuthSession } from '@/utils/admin-auth-session';
 import { normalizeError } from '@/utils/error-handler';
 
@@ -38,7 +45,23 @@ export default function AdminLoginPage() {
   const [signupSecretKey, setSignupSecretKey] = useState('');
   const [signupErrorMessage, setSignupErrorMessage] = useState('');
   const [isSignupSubmitting, setIsSignupSubmitting] = useState(false);
+  const [backendTarget, setBackendTarget] = useState<AdminBackendTarget>(() =>
+    getStoredAdminBackendTarget()
+  );
   const nextPath = useMemo(() => resolveNextPath(router.query.next), [router.query.next]);
+
+  const handleBackendTargetChange = (nextTarget: AdminBackendTarget) => {
+    if (nextTarget === backendTarget) return;
+
+    setBackendTarget(nextTarget);
+    persistAdminBackendTarget(nextTarget);
+    setErrorMessage('');
+    setSignupErrorMessage('');
+    showToast({
+      title: `${ADMIN_BACKEND_TARGET_LABELS[nextTarget]} 연결로 변경되었습니다.`,
+      icon: 'check',
+    });
+  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -52,6 +75,7 @@ export default function AdminLoginPage() {
     setIsSubmitting(true);
 
     try {
+      persistAdminBackendTarget(backendTarget);
       const response = await postAdminLogin({
         email: email.trim(),
         password,
@@ -98,6 +122,7 @@ export default function AdminLoginPage() {
     setIsSignupSubmitting(true);
 
     try {
+      persistAdminBackendTarget(backendTarget);
       const response = await postAdminRegister({
         username: signupUsername.trim(),
         email: signupEmail.trim(),
@@ -128,6 +153,15 @@ export default function AdminLoginPage() {
           <Text typo="body9" css={adminHeroDescription}>
             업체 등록과 수정은 관리자 토큰으로만 접근합니다.
           </Text>
+        </div>
+
+        <div css={backendSelectorSection}>
+          <AdminBackendTargetSelector
+            value={backendTarget}
+            onChange={handleBackendTargetChange}
+            isTestEnabled={isAdminTestBackendEnabled}
+            disabled={isSubmitting || isSignupSubmitting}
+          />
         </div>
 
         <form css={formLayout} onSubmit={handleSubmit}>
@@ -270,6 +304,10 @@ const titleArea = css`
   flex-direction: column;
   gap: 10px;
   margin-bottom: 24px;
+`;
+
+const backendSelectorSection = css`
+  margin-bottom: 22px;
 `;
 
 const formLayout = css`

--- a/src/pages/api/admin/companies/[[...path]].ts
+++ b/src/pages/api/admin/companies/[[...path]].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { proxyRawToBackend, validateMethod } from '@/server/http/bff-proxy';
+import { getAdminBackendBaseUrl } from '@/server/config/admin-backend';
 
 export const config = {
   api: {
@@ -97,10 +98,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(404).json({ message: 'Not Found' });
   }
 
+  const backendBaseUrl = getAdminBackendBaseUrl(req);
+
   return proxyRawToBackend({
     req,
     res,
     method,
+    baseURL: backendBaseUrl,
     backendPath: route.backendPath,
     omitQueryKeys: route.omitQueryKeys,
     errorMessage: 'Admin companies proxy failed',

--- a/src/pages/api/admin/influencers/[[...path]].ts
+++ b/src/pages/api/admin/influencers/[[...path]].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { proxyJsonToBackend, validateMethod } from '@/server/http/bff-proxy';
+import { getAdminBackendBaseUrl } from '@/server/config/admin-backend';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
@@ -58,10 +59,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(404).json({ message: 'Not Found' });
   }
 
+  const backendBaseUrl = getAdminBackendBaseUrl(req);
+
   return proxyJsonToBackend({
     req,
     res,
     method,
+    baseURL: backendBaseUrl,
     backendPath: route.backendPath,
     omitQueryKeys: route.omitQueryKeys,
     errorMessage: 'Admin influencers proxy failed',

--- a/src/pages/api/admin/programs/[[...path]].ts
+++ b/src/pages/api/admin/programs/[[...path]].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { proxyRawToBackend, validateMethod } from '@/server/http/bff-proxy';
+import { getAdminBackendBaseUrl } from '@/server/config/admin-backend';
 
 export const config = {
   api: {
@@ -82,10 +83,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(404).json({ message: 'Not Found' });
   }
 
+  const backendBaseUrl = getAdminBackendBaseUrl(req);
+
   return proxyRawToBackend({
     req,
     res,
     method,
+    baseURL: backendBaseUrl,
     backendPath: route.backendPath,
     omitQueryKeys: route.omitQueryKeys,
     errorMessage: 'Admin programs proxy failed',

--- a/src/pages/api/admin/promotion-codes/[codeId].ts
+++ b/src/pages/api/admin/promotion-codes/[codeId].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { proxyJsonToBackend, validateMethod } from '@/server/http/bff-proxy';
+import { getAdminBackendBaseUrl } from '@/server/config/admin-backend';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const method = validateMethod(req, res, ['PATCH', 'DELETE']);
@@ -10,10 +11,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ message: 'Missing codeId' });
   }
 
+  const backendBaseUrl = getAdminBackendBaseUrl(req);
+
   return proxyJsonToBackend({
     req,
     res,
     method,
+    baseURL: backendBaseUrl,
     backendPath: `/api/users/admin/promotion-codes/${codeId}`,
     omitQueryKeys: ['codeId'],
     errorMessage: 'Admin promotion-codes proxy failed',

--- a/src/pages/api/admin/reservations/[[...path]].ts
+++ b/src/pages/api/admin/reservations/[[...path]].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { proxyJsonToBackend, validateMethod } from '@/server/http/bff-proxy';
+import { getAdminBackendBaseUrl } from '@/server/config/admin-backend';
 
 const isNonEmpty = (value: string | undefined): value is string => !!value && value.length > 0;
 
@@ -71,10 +72,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(404).json({ message: 'Not Found' });
   }
 
+  const backendBaseUrl = getAdminBackendBaseUrl(req);
+
   return proxyJsonToBackend({
     req,
     res,
     method,
+    baseURL: backendBaseUrl,
     backendPath: route.backendPath,
     omitQueryKeys: route.omitQueryKeys,
     errorMessage: 'Admin reservations proxy failed',

--- a/src/pages/api/admin/reviews/companies/[companyId].ts
+++ b/src/pages/api/admin/reviews/companies/[companyId].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { proxyJsonToBackend, validateMethod } from '@/server/http/bff-proxy';
+import { getAdminBackendBaseUrl } from '@/server/config/admin-backend';
 
 const resolveCompanyId = (value: string | string[] | undefined) => {
   if (typeof value === 'string') return value.trim();
@@ -16,10 +17,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ message: 'Invalid companyId' });
   }
 
+  const backendBaseUrl = getAdminBackendBaseUrl(req);
+
   return proxyJsonToBackend({
     req,
     res,
     method,
+    baseURL: backendBaseUrl,
     backendPath: `/non/guest-reviews/company/${companyId}`,
     omitQueryKeys: ['companyId'],
     errorMessage: 'Admin company reviews proxy failed',

--- a/src/pages/api/admin/users/[[...path]].ts
+++ b/src/pages/api/admin/users/[[...path]].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { proxyJsonToBackend, validateMethod } from '@/server/http/bff-proxy';
+import { getAdminBackendBaseUrl } from '@/server/config/admin-backend';
 
 const isNonEmpty = (value: string | undefined): value is string => !!value && value.length > 0;
 
@@ -45,10 +46,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(404).json({ message: 'Not Found' });
   }
 
+  const backendBaseUrl = getAdminBackendBaseUrl(req);
+
   return proxyJsonToBackend({
     req,
     res,
     method,
+    baseURL: backendBaseUrl,
     backendPath: route.backendPath,
     omitQueryKeys: route.omitQueryKeys,
     errorMessage: 'Admin users proxy failed',

--- a/src/server/api/admin/login-admin-handler.ts
+++ b/src/server/api/admin/login-admin-handler.ts
@@ -8,6 +8,7 @@ import {
   extractContractMessage,
   resolveTraceId,
 } from '@/server/http/api-contract';
+import { getAdminBackendBaseUrl } from '@/server/config/admin-backend';
 import { createAdminRefreshTokenCookies } from '@/server/auth/cookies';
 import { applyRefreshTokenCookies, sanitizeAuthPayload } from '@/server/api/auth/auth-proxy-utils';
 
@@ -28,12 +29,18 @@ export const handleAdminLogin = async (req: NextApiRequest, res: NextApiResponse
   }
 
   try {
-    const backendResponse = await postBackend(BACKEND_ADMIN_LOGIN_PATH, req.body, {
-      headers: {
-        'Content-Type': 'application/json',
+    const backendBaseUrl = getAdminBackendBaseUrl(req);
+    const backendResponse = await postBackend(
+      BACKEND_ADMIN_LOGIN_PATH,
+      req.body,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        timeout: 7000,
       },
-      timeout: 7000,
-    });
+      { baseURL: backendBaseUrl }
+    );
 
     applyRefreshTokenCookies(res, backendResponse.data, createAdminRefreshTokenCookies);
     const payload = sanitizeAuthPayload(resolveBackendPayload(backendResponse.data));

--- a/src/server/api/admin/register-admin-handler.ts
+++ b/src/server/api/admin/register-admin-handler.ts
@@ -8,6 +8,7 @@ import {
   extractContractMessage,
   resolveTraceId,
 } from '@/server/http/api-contract';
+import { getAdminBackendBaseUrl } from '@/server/config/admin-backend';
 import { createAdminRefreshTokenCookies } from '@/server/auth/cookies';
 import { applyRefreshTokenCookies, sanitizeAuthPayload } from '@/server/api/auth/auth-proxy-utils';
 
@@ -28,12 +29,18 @@ export const handleAdminRegister = async (req: NextApiRequest, res: NextApiRespo
   }
 
   try {
-    const backendResponse = await postBackend(BACKEND_ADMIN_REGISTER_PATH, req.body, {
-      headers: {
-        'Content-Type': 'application/json',
+    const backendBaseUrl = getAdminBackendBaseUrl(req);
+    const backendResponse = await postBackend(
+      BACKEND_ADMIN_REGISTER_PATH,
+      req.body,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        timeout: 7000,
       },
-      timeout: 7000,
-    });
+      { baseURL: backendBaseUrl }
+    );
 
     applyRefreshTokenCookies(res, backendResponse.data, createAdminRefreshTokenCookies);
     const payload = sanitizeAuthPayload(resolveBackendPayload(backendResponse.data));

--- a/src/server/api/admin/token-reissue-handler.ts
+++ b/src/server/api/admin/token-reissue-handler.ts
@@ -4,6 +4,7 @@ import { ADMIN_AUTH_COOKIE_KEYS } from '@/constants/commons/auth-cookies';
 import { createAdminRefreshTokenCookies } from '@/server/auth/cookies';
 import { resolvePayload, extractRefreshToken } from '@/server/auth/token-payload';
 import { postBackend, resolveBackendPayload } from '@/server/http/backend-client';
+import { getAdminBackendBaseUrl } from '@/server/config/admin-backend';
 import {
   buildErrorContract,
   buildSuccessContract,
@@ -32,6 +33,7 @@ export const handleAdminTokenReissue = async (req: NextApiRequest, res: NextApiR
   try {
     const refreshTokenFromCookie = req.cookies?.[ADMIN_AUTH_COOKIE_KEYS.REFRESH_TOKEN];
     const refreshToken = refreshTokenFromCookie || undefined;
+    const backendBaseUrl = getAdminBackendBaseUrl(req);
 
     const backendResponse = await postBackend(
       BACKEND_ADMIN_REISSUE_PATH,
@@ -41,7 +43,8 @@ export const handleAdminTokenReissue = async (req: NextApiRequest, res: NextApiR
           'Content-Type': 'application/json',
           cookie: req.headers.cookie ?? '',
         },
-      }
+      },
+      { baseURL: backendBaseUrl }
     );
 
     const payload = resolvePayload(resolveBackendPayload(backendResponse.data));

--- a/src/server/config/admin-backend.ts
+++ b/src/server/config/admin-backend.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest } from 'next';
+import {
+  ADMIN_BACKEND_TARGET_COOKIE,
+  DEFAULT_ADMIN_BACKEND_TARGET,
+  isAdminBackendTarget,
+  type AdminBackendTarget,
+} from '@/constants/admin-backend';
+import { getBackendBaseUrl } from './backend-url';
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
+
+const isAdminTestBackendConfigured = () => Boolean(process.env.BACKEND_TEST_API_URL?.trim());
+
+export const resolveAdminBackendTarget = (value: string | undefined | null): AdminBackendTarget => {
+  if (!isAdminBackendTarget(value)) return DEFAULT_ADMIN_BACKEND_TARGET;
+  if (value === 'test' && !isAdminTestBackendConfigured()) return DEFAULT_ADMIN_BACKEND_TARGET;
+  return value;
+};
+
+export const getAdminBackendTarget = (req?: Pick<NextApiRequest, 'cookies'>): AdminBackendTarget =>
+  resolveAdminBackendTarget(req?.cookies?.[ADMIN_BACKEND_TARGET_COOKIE]);
+
+export const getAdminBackendBaseUrl = (req?: Pick<NextApiRequest, 'cookies'>): string => {
+  const target = getAdminBackendTarget(req);
+
+  if (target === 'test') {
+    const testBackendBaseUrl = process.env.BACKEND_TEST_API_URL?.trim();
+
+    if (!testBackendBaseUrl) {
+      throw new Error('Missing BACKEND_TEST_API_URL');
+    }
+
+    return trimTrailingSlash(testBackendBaseUrl);
+  }
+
+  return getBackendBaseUrl();
+};

--- a/src/server/http/backend-client.ts
+++ b/src/server/http/backend-client.ts
@@ -4,12 +4,13 @@ import { getBackendBaseUrl } from '@/server/config/backend-url';
 const DEFAULT_TIMEOUT_MS = 10000;
 
 export const requestBackend = async <T = unknown>(
-  config: AxiosRequestConfig
+  config: AxiosRequestConfig,
+  options?: { baseURL?: string }
 ): Promise<AxiosResponse<T>> => {
   const { headers, ...restConfig } = config;
 
   return axios.request<T>({
-    baseURL: getBackendBaseUrl(),
+    baseURL: options?.baseURL ?? getBackendBaseUrl(),
     timeout: DEFAULT_TIMEOUT_MS,
     ...restConfig,
     headers: {
@@ -22,14 +23,18 @@ export const requestBackend = async <T = unknown>(
 export const postBackend = async <T = unknown>(
   path: string,
   body?: unknown,
-  config?: Omit<AxiosRequestConfig, 'url' | 'method' | 'data'>
+  config?: Omit<AxiosRequestConfig, 'url' | 'method' | 'data'>,
+  options?: { baseURL?: string }
 ) =>
-  requestBackend<T>({
-    ...(config ?? {}),
-    method: 'POST',
-    url: path,
-    data: body,
-  });
+  requestBackend<T>(
+    {
+      ...(config ?? {}),
+      method: 'POST',
+      url: path,
+      data: body,
+    },
+    options
+  );
 
 export const resolveBackendPayload = <T = unknown>(data: unknown): T => {
   if (data && typeof data === 'object' && 'response' in data) {

--- a/src/server/http/bff-proxy.ts
+++ b/src/server/http/bff-proxy.ts
@@ -71,18 +71,20 @@ const requestJsonFromBackend = async ({
   backendPath,
   omitQueryKeys,
   includeCookie,
+  baseURL,
 }: {
   req: NextApiRequest;
   method: HttpMethod;
   backendPath: string;
   omitQueryKeys?: string[];
   includeCookie?: boolean;
+  baseURL?: string;
 }) => {
-  const baseURL = getBackendBaseUrl();
+  const resolvedBaseUrl = baseURL ?? getBackendBaseUrl();
 
   return axios.request({
     method,
-    url: `${baseURL}${backendPath}`,
+    url: `${resolvedBaseUrl}${backendPath}`,
     params: toAxiosParams(req.query, omitQueryKeys),
     data: METHODS_WITH_BODY.has(method) ? req.body : undefined,
     headers: buildHeaders(req, { includeCookie }),
@@ -110,6 +112,7 @@ export const proxyJsonToBackend = async ({
   backendPath,
   omitQueryKeys,
   includeCookie,
+  baseURL,
   errorMessage,
 }: {
   req: NextApiRequest;
@@ -118,6 +121,7 @@ export const proxyJsonToBackend = async ({
   backendPath: string;
   omitQueryKeys?: string[];
   includeCookie?: boolean;
+  baseURL?: string;
   errorMessage: string;
 }) => {
   try {
@@ -127,6 +131,7 @@ export const proxyJsonToBackend = async ({
       backendPath,
       omitQueryKeys,
       includeCookie,
+      baseURL,
     });
 
     return res.status(response.status).send(response.data);
@@ -142,6 +147,7 @@ export const proxyRawToBackend = async ({
   backendPath,
   omitQueryKeys,
   includeCookie,
+  baseURL,
   errorMessage,
 }: {
   req: NextApiRequest;
@@ -150,13 +156,14 @@ export const proxyRawToBackend = async ({
   backendPath: string;
   omitQueryKeys?: string[];
   includeCookie?: boolean;
+  baseURL?: string;
   errorMessage: string;
 }) => {
   try {
-    const baseURL = getBackendBaseUrl();
+    const resolvedBaseUrl = baseURL ?? getBackendBaseUrl();
     const response = await axios.request({
       method,
-      url: `${baseURL}${backendPath}`,
+      url: `${resolvedBaseUrl}${backendPath}`,
       params: toAxiosParams(req.query, omitQueryKeys),
       data: METHODS_WITH_BODY.has(method) ? req : undefined,
       headers: buildHeaders(req, {

--- a/src/utils/admin-backend-target.ts
+++ b/src/utils/admin-backend-target.ts
@@ -1,0 +1,23 @@
+import {
+  ADMIN_BACKEND_TARGET_COOKIE,
+  DEFAULT_ADMIN_BACKEND_TARGET,
+  isAdminBackendTarget,
+  type AdminBackendTarget,
+} from '@/constants/admin-backend';
+import { getCookie, setCookie } from '@/utils/cookie';
+
+const ADMIN_BACKEND_TARGET_COOKIE_DAYS = 30;
+
+export const isAdminTestBackendEnabled =
+  process.env.NEXT_PUBLIC_ADMIN_TEST_BACKEND_ENABLED === 'true';
+
+export const getStoredAdminBackendTarget = (): AdminBackendTarget => {
+  const target = getCookie(ADMIN_BACKEND_TARGET_COOKIE);
+  if (!isAdminBackendTarget(target)) return DEFAULT_ADMIN_BACKEND_TARGET;
+  if (target === 'test' && !isAdminTestBackendEnabled) return DEFAULT_ADMIN_BACKEND_TARGET;
+  return target;
+};
+
+export const persistAdminBackendTarget = (target: AdminBackendTarget) => {
+  setCookie(ADMIN_BACKEND_TARGET_COOKIE, target, ADMIN_BACKEND_TARGET_COOKIE_DAYS);
+};


### PR DESCRIPTION
## 📝 관련 문서 레퍼런스
   ```
   - [Issue] : #187 
   - [Slack] : 
   - [Notion] : 
   ```

<br/>

## 💻 주요 변경 사항은 무엇인가요?
   ```
- 어드민 전용 백엔드 선택값을 쿠키로 저장하도록 추가
- 관리자 로그인/회원가입/토큰 재발급이 선택된 백엔드를 사용하도록 수정
- `/api/admin/**` 프록시가 선택된 운영/테스트 백엔드로 요청하도록 수정
- 어드민 로그인 화면과 상단 헤더에 서버 전환 UI 추가
- 테스트 서버 URL 미설정 시 테스트 선택지를 비활성화하도록 처리
- 이슈 초안 문서 추가

## 환경 변수
- `BACKEND_API_URL`: 운영 서버 기본 URL
- `BACKEND_TEST_API_URL`: 테스트 서버 URL
- `NEXT_PUBLIC_ADMIN_TEST_BACKEND_ENABLED`: `BACKEND_TEST_API_URL` 존재 여부로 build 시 자동 계산

   ```
   
<br/>

## 📚 추가된 라이브러리
   ```
   - [추가] : NO
   ```

<br/>

## 📱 결과 화면 (선택)

  
<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)
   ```
- 운영 서버 선택 상태에서 기존 관리자 기능이 정상 동작하는지
- 테스트 서버 선택 후 재로그인하면 관리자 목록/상세/수정/예약 기능이 테스트 서버 기준으로 동작하는지
- 서버 전환 시 기존 관리자 세션이 정리되고 로그인 페이지로 이동하는지
   ```
